### PR TITLE
Exclude Specific Clients from Browser Bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+  entry: './src/index.ts',
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    fallback: {
+      crypto: require.resolve('crypto-browserify'),
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+    },
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'docs'),
+    library: 'EmblemVaultSdk',
+    libraryTarget: 'umd',
+    globalObject: 'this',
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
+    new webpack.NormalModuleReplacementPlugin(
+      /src\/clients\/emblemVaultSolanaWalletClient\.ts$/,
+      path.resolve(__dirname, 'src/clients/emptyClient.ts')
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /src\/clients\/emblemVaultWalletClient\.ts$/,
+      path.resolve(__dirname, 'src/clients/emptyClient.ts')
+    )
+  ]
+};


### PR DESCRIPTION
This pull request modifies the webpack configuration in the /v3/experiment branch to exclude the specified clients from the browser bundle. The clients `emblemVaultSolanaWalletClient.ts` and `emblemVaultWalletClient.ts` are replaced with an empty client implementation during the build process. This ensures that these clients are not included in the final bundle, addressing issue #10. 

Changes made:
- Added a new `webpack.config.js` file that includes the necessary configuration to handle TypeScript files and exclude the specified clients using `NormalModuleReplacementPlugin`.

---

> This pull request was co-created with Cosine Genie

Original Task: [emblem-vault-sdk/pbeqowqqkcqo](https://cosine.sh/7nu8gwetjc66/emblem-vault-sdk/task/pbeqowqqkcqo)
Author: Shannon Code
