### PR TITLE
Exclude Concrete Clients from Browser Bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "bundle": "npm run build && browserify dist/index.js -o dist/bundle.js && cp dist/bundle.js docs/bundle.js",
     "watch": "onchange 'src/*.ts' -- npm run bundle"
   },
+  "browser": {
+    "./dist/clients/emblemVaultSolanaWalletClient.js": false,
+    "./dist/clients/emblemVaultWalletClient.js": false
+  },
   "types": "types/index.d.ts",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This pull request addresses issue #10 by modifying the `package.json` file to exclude the `emblemVaultSolanaWalletClient` and `emblemVaultWalletClient` from the browser bundle. The changes add entries under the `browser` field in `package.json`, setting these clients to `false`, which prevents them from being included when compiling for the browser. This ensures that unnecessary clients are not bundled, optimizing the final output.

---

> This pull request was co-created with Cosine Genie

Original Task: [emblem-vault-sdk/3zwhzw7piay3](https://cosine.sh/7nu8gwetjc66/emblem-vault-sdk/task/3zwhzw7piay3)
Author: Shannon Code
